### PR TITLE
fix: correct indent of service.annotations

### DIFF
--- a/apps/stable/nginx-ingress/values.yaml.gotmpl
+++ b/apps/stable/nginx-ingress/values.yaml.gotmpl
@@ -1,7 +1,7 @@
 controller:
   replicaCount: 3
   extraArgs:
-    publish-service: kube-system/jxing-nginx-ingress-controller
+    publish-service: nginx/jxing-nginx-ingress-controller
   service:
     omitClusterIP: true
   {{- if eq .Values.jxRequirements.cluster.provider "kind" }}
@@ -10,8 +10,8 @@ controller:
     type: {{ .Values.jxRequirements.ingress.serviceType }}
   {{- end }}
   {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
   {{- end }}
 defaultBackend:
   service:


### PR DESCRIPTION
also using the nginx namespace instead of kube-system because ingress is
installed there now