### PR TITLE
fix: cleanup IRSA for EKS

### DIFF
--- a/kubeProviders/eks/templates/irsa.tmpl.yaml
+++ b/kubeProviders/eks/templates/irsa.tmpl.yaml
@@ -8,22 +8,28 @@ metadata:
 iam:
   withOIDC: true
   serviceAccounts:
-{{- if .IAM.TektonBotPolicy }}
   - metadata:
       name: tekton-bot
       namespace: jx
       labels: {aws-usage: "jenkins-x"}
     attachPolicyARNs:
-    - {{.IAM.TektonBotPolicy | quote}}
-{{- end }}
-{{- if .IAM.ExternalDNSPolicy }}
+    - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser
   - metadata:
       name: external-dns-external-dns
       namespace: jx
       labels: {aws-usage: "jenkins-x"}
-    attachPolicyARNs:
-    - {{.IAM.ExternalDNSPolicy | quote}}
-{{- end }}
+    attachPolicy:
+      Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - route53:ChangeResourceRecordSets
+          Resource: "arn:aws:route53:::hostedzone/*"
+        - Effect: Allow
+          Action:
+          - route53:ListHostedZones
+          - route53:ListResourceRecordSets
+          Resource: "*"
 {{- if .IAM.CertManagerPolicy }}
   - metadata:
       name: cert-manager-cert-manager

--- a/kubeProviders/eks/templates/jenkinsx-policies.yml
+++ b/kubeProviders/eks/templates/jenkinsx-policies.yml
@@ -1,42 +1,5 @@
 Description: 'Template to generate the necessary IAM Policies for Jenkins-X EKS support '
 Resources:
-  CFNJenkinsXPolicies:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: !Join [ "-", [ CFNTektonBotPolicy, Ref: PoliciesSuffixParameter] ]
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Action:
-          - cloudformation:ListStacks
-          - cloudformation:DescribeStacks
-          - cloudformation:CreateStack
-          - cloudformation:DeleteStack
-          - eks:*
-          - s3:*
-          - iam:DetachRolePolicy
-          - iam:GetPolicy
-          - iam:CreatePolicy
-          - iam:DeleteRole
-          - iam:GetOpenIDConnectProvider
-          Resource: "*"
-  CFNExternalDNSPolicies:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      ManagedPolicyName: !Join [ "-", [ CFNExternalDNSPolicy, Ref: PoliciesSuffixParameter] ]
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Action:
-          - route53:ChangeResourceRecordSets
-          Resource: "arn:aws:route53:::hostedzone/*"
-        - Effect: Allow
-          Action:
-          - route53:ListHostedZones
-          - route53:ListResourceRecordSets
-          Resource: "*"
   CFNCertManagerPolicies:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -61,18 +24,6 @@ Parameters:
     Type: String
     Description: A suffix so we can create different policies on each execution
 Outputs:
-  CFNTektonBotPolicy:
-    Value:
-      Ref: CFNJenkinsXPolicies
-    Description: The ARN of the created policy
-    Export:
-      Name: !Join [ "-", [ TektonBotPolicy, Ref: PoliciesSuffixParameter] ]
-  CFNExternalDNSPolicy:
-    Value:
-      Ref: CFNExternalDNSPolicies
-    Description: The ARN of the created policy
-    Export:
-      Name: !Join [ "-", [ ExternalDNSPolicy, Ref: PoliciesSuffixParameter] ]
   CFNCertManagerPolicy:
     Value:
       Ref: CFNCertManagerPolicies


### PR DESCRIPTION
removing a few unnecessary permissions. we can probably get rid of jenkinsx-policies.yaml entirely. right not jenkinsx-policies is not executed in an idempotent manner