### PR TITLE
fix: use older version till postStart.sh is fixed for new version

### DIFF
--- a/charts/jenkins-x/nexus.yml
+++ b/charts/jenkins-x/nexus.yml
@@ -1,0 +1,2 @@
+gitUrl: https://github.com/jenkins-x-charts/nexus
+version: 0.1.21


### PR DESCRIPTION
workaround for https://github.com/jenkins-x-charts/nexus/issues/49