### PR TITLE
fix: use the right variable to configure podSecurityContext

### DIFF
--- a/apps/bitnami/external-dns/values.yaml.gotmpl
+++ b/apps/bitnami/external-dns/values.yaml.gotmpl
@@ -4,7 +4,7 @@ sources:
 provider: aws
 aws:
   region: {{ .Values.jxRequirements.cluster.region }}
-securityContext:
+podSecurityContext:
   fsGroup: 65534
 {{- else if eq .Values.jxRequirements.cluster.provider "gke" }}
 provider: google


### PR DESCRIPTION
https://github.com/bitnami/charts/blob/master/bitnami/external-dns/templates/deployment.yaml#L26