### PR TITLE
feat: create SA in EKS based on aws.helmSa

### DIFF
--- a/apps/bitnami/external-dns/values.yaml.gotmpl
+++ b/apps/bitnami/external-dns/values.yaml.gotmpl
@@ -21,8 +21,13 @@ rbac:
   serviceAccountAnnotations:
     iam.gke.io/gcp-service-account: {{ .Values.jxRequirements.cluster.clusterName }}-ex@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com
 {{- else if eq .Values.jxRequirements.cluster.provider "eks" }}
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
   serviceAccountAnnotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-external-dns
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-external-dns
+{{- else }}
+  serviceAccountCreate: false
+{{- end }}
+
 {{- end }}
 
 domainFilters:

--- a/apps/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
+++ b/apps/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
@@ -6,6 +6,15 @@ controllerbuild:
 {{- end }}
 
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+controllerbuild:
+  serviceaccount:
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-jxboot-helmfile-resources-controllerbuild
+{{- else }}
+    enabled: false
+{{- end }}
+
 podTemplates:
   agent:
     dockerConfig: true

--- a/apps/jenkins-x/jxui/values.yaml.gotmpl
+++ b/apps/jenkins-x/jxui/values.yaml.gotmpl
@@ -1,5 +1,9 @@
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
 serviceaccount:
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-jxui
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-jxui
+{{- else }}
+  enabled: false
+{{- end }}
 {{- end }}

--- a/apps/jenkins-x/tekton/values.yaml.gotmpl
+++ b/apps/jenkins-x/tekton/values.yaml.gotmpl
@@ -15,8 +15,13 @@ auth:
 
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
 serviceaccount:
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-tekton-bot
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-tekton-bot
+{{- else }}
+  enabled: false
+{{- end }}
+
 {{- else if eq .Values.jxRequirements.cluster.provider "gke" }}
 serviceaccount:
   annotations:

--- a/apps/jetstack/cert-manager/values.yaml.gotmpl
+++ b/apps/jetstack/cert-manager/values.yaml.gotmpl
@@ -7,8 +7,13 @@ securityContext:
   enabled: true
   fsGroup: 1001
 serviceAccount:
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-cert-manager-cert-manager
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-cert-manager
+{{- else }}
+  create: false
+{{- end }}
+
 {{- end }}
 
 webhook:

--- a/apps/stable/cluster-autoscaler/values.yaml.gotmpl
+++ b/apps/stable/cluster-autoscaler/values.yaml.gotmpl
@@ -13,8 +13,13 @@ image:
 rbac:
   create: true
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
   serviceAccount:
     name: cluster-autoscaler
   serviceAccountAnnotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-cluster-autoscaler-cluster-autoscaler
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-cluster-autoscaler-cluster-autoscaler
+{{- else }}
+  serviceAccount:
+    create: false
+{{- end }}
 {{- end }}

--- a/charts/bitnami/external-dns.yml
+++ b/charts/bitnami/external-dns.yml
@@ -1,1 +1,1 @@
-version: 2.20.5
+version: 2.20.10


### PR DESCRIPTION
- if `jxRequirements.cluster.aws.helmSa` is true: create SA with annotations to bind to the IAM Role with convention: `arn:aws:iam::<accountId>:role/<clustername>-<namespace>-<saName>`
- otherwise: don't create SA

fix jenkins-x-labs/issues#17